### PR TITLE
Styling change: Background color on <code> elements to make the cheatsheet look a little better

### DIFF
--- a/BitCycle/bitcycle.css
+++ b/BitCycle/bitcycle.css
@@ -82,3 +82,9 @@ span[contenteditable] {
     background: #888;
     cursor: default;
 }
+
+code {
+    padding: 0.25rem;
+    background-color: #ddd;
+    border-radius: 0.25rem;
+}


### PR DESCRIPTION
Should make `<code>` elements look a bit like they look on stack overflow or on GitHub